### PR TITLE
Updated to current dehydrated version and added sub-auth-id support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,7 @@ To use it, just export environment variables, and make [dehydrated](https://gith
     $ export CLOUDNS_AUTH_ID="<auth-id here>"
     $ export CLOUDNS_AUTH_PASSWORD="<auth-password here>"
 
-Sub-users are not supported.
+Alternatively you can export CLOUDNS_SUB_AUTH_ID instead of CLOUDNS_AUTH_ID to use API sub user:
+
+    $ export CLOUDNS_SUB_AUTH_ID="<sub-auth-id here>"
+    $ export CLOUDNS_AUTH_PASSWORD="<auth-password here>"

--- a/hook.sh
+++ b/hook.sh
@@ -51,7 +51,7 @@ deploy_challenge() {
     echo "  + creating TXT record for ${1}"
     do_request \
         /dns/add-record.json \
-        "domain-name=${domain}&record-type=TXT&host=_acme-challenge${prefix:+.${prefix}}&record=${3}&ttl=60" \
+        "domain-name=${domain}&record-type=TXT&host=_acme-challenge${prefix:+.${prefix}}&record=${2}&ttl=60" \
         | grep -i success &> /dev/null
     echo "  + waiting for propagation ..."
     sleep 5

--- a/hook.sh
+++ b/hook.sh
@@ -82,10 +82,26 @@ clean_challenge() {
         | grep -i success &> /dev/null
 }
 
+unchanged_cert() {
+    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}"
+
+    # This hook is called once for each certificate that is still
+    # valid and therefore wasn't reissued.
+}
+
 invalid_challenge() {
+    local DOMAIN="${1}" RESPONSE="${2}"
+
     # This hook is called if the challenge response has failed, so domain
     # owners can be aware and act accordingly.
-    local DOMAIN="${1}" RESPONSE="${2}"
+}
+
+deploy_cert() {
+    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}" TIMESTAMP="${6}"
+
+    # This hook is called once for each certificate that has been
+    # produced. Here you might, for instance, copy your new certificates
+    # to service-specific locations and reload the service.
 }
 
 startup_hook() {

--- a/hook.sh
+++ b/hook.sh
@@ -39,6 +39,7 @@ do_request() {
     local args="auth-id=${CLOUDNS_AUTH_ID}&auth-password=${CLOUDNS_AUTH_PASSWORD}&${2}"
     curl \
         --silent \
+        --show-error \
         "https://api.cloudns.net${1}?${args}"
 }
 

--- a/hook.sh
+++ b/hook.sh
@@ -51,7 +51,7 @@ deploy_challenge() {
     echo "  + creating TXT record for ${1}"
     do_request \
         /dns/add-record.json \
-        "domain-name=${domain}&record-type=TXT&host=_acme-challenge${prefix:+.${prefix}}&record=${2}&ttl=60" \
+        "domain-name=${domain}&record-type=TXT&host=_acme-challenge${prefix:+.${prefix}}&record=${3}&ttl=60" \
         | grep -i success &> /dev/null
     echo "  + waiting for propagation ..."
     sleep 5

--- a/hook.sh
+++ b/hook.sh
@@ -81,23 +81,27 @@ clean_challenge() {
         | grep -i success &> /dev/null
 }
 
+invalid_challenge() {
+    # This hook is called if the challenge response has failed, so domain
+    # owners can be aware and act accordingly.
+    local DOMAIN="${1}" RESPONSE="${2}"
+}
 
-case "${1:-}" in
-    deploy_challenge)
-        deploy_challenge "${2}" "${4}"
-        ;;
-    clean_challenge)
-        clean_challenge "${2}"
-        ;;
-    deploy_cert)
-        ;;
-    unchanged_cert)
-        ;;
-    invalid_challenge)
-        ;;
-    request_failure)
-        ;;
-    *)
-        die "unknown operation"
-        ;;
-esac
+startup_hook() {
+  # This hook is called before the cron command to do some initial tasks
+  # (e.g. starting a webserver).
+
+  :
+}
+
+exit_hook() {
+  # This hook is called at the end of the cron command and can be used to
+  # do some final (cleanup or other) tasks.
+
+  :
+}
+
+HANDLER="$1"; shift
+if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|deploy_cert|unchanged_cert|invalid_challenge|request_failure|startup_hook|exit_hook)$ ]]; then
+  "$HANDLER" "$@"
+fi

--- a/hook.sh
+++ b/hook.sh
@@ -1,9 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
 export LC_ALL=C
-
 
 die() {
     echo "error: $@"
@@ -34,12 +33,18 @@ get_prefix() {
 
 
 do_request() {
-    test -z "${CLOUDNS_AUTH_ID}" && return 1
+    CLOUDNS_AUTH_ID="${CLOUDNS_AUTH_ID-}"
+    test -z "${CLOUDNS_AUTH_ID}" && test -z "${CLOUDNS_SUB_AUTH_ID}" && return 1
     test -z "${CLOUDNS_AUTH_PASSWORD}" && return 1
-    local args="auth-id=${CLOUDNS_AUTH_ID}&auth-password=${CLOUDNS_AUTH_PASSWORD}&${2}"
+    local args=""
+    if test -n "${CLOUDNS_AUTH_ID}"; then
+      args="auth-id=${CLOUDNS_AUTH_ID}"
+    else
+      args="sub-auth-id=${CLOUDNS_SUB_AUTH_ID}"
+    fi
+    args="${args}&auth-password=${CLOUDNS_AUTH_PASSWORD}&${2}"
     curl \
         --silent \
-        --show-error \
         "https://api.cloudns.net${1}?${args}"
 }
 


### PR DESCRIPTION
I've updated the hook to be compatible with the current dehydrated version and added missing functions so it can be used right after download. 

I've also added alternative sub-auth-id authentication support. 

There is also a fix for deploy challenge since the second parameter is the file containing token and the third is the token_value which should be set as the value of the TXT record